### PR TITLE
updated graphql queries for new backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@storybook/react": "4.1.11",
     "@svgr/webpack": "4.1.0",
     "apollo-boost": "0.1.28",
+    "apollo-cache-inmemory": "^1.4.3",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "24.1.0",

--- a/src/components/onboard/GQLOnboard.js
+++ b/src/components/onboard/GQLOnboard.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
 
 import { connect } from 'react-redux';
@@ -15,50 +14,13 @@ import LocalizedOnboardStep4 from './OnboardStep4';
 import LocalizedOnboardStep5 from './OnboardStep5';
 import LocalizedOnboardStep6 from './OnboardStep6';
 
-const PROFILE_INFO_QUERY = gql`
-query profileInfoQuery($gcID: String!) {
-  profiles(gcID: $gcID) {
-    gcID
-    name
-    email
-    avatar
-    mobilePhone
-    officePhone
-    supervisor {
-      gcID
-      name
-    }
-    address {
-      id
-      streetAddress
-      city
-      province
-      postalCode
-      country
-    }
-    titleEn
-    titleFr
-    org {
-      id
-      nameEn
-      nameFr
-      organization {
-        id
-        nameEn
-        nameFr
-        acronymEn
-        acronymFr
-      }
-    }
-  }
-}`;
+import { GET } from '../../gql/profile';
 
 const mapStateToProps = ({ user }) => {
   const props = {};
   if (user) {
     props.accessToken = user.access_token;
     props.myGcID = user.profile.sub;
-    props.modifyProfile = user.profile.modify_profile === 'True';
   }
   return props;
 };
@@ -81,7 +43,7 @@ export const OnboardMod = (props) => {
     <Query
       variables={{ gcID: (String(myGcID)) }}
       skip={canSkip}
-      query={PROFILE_INFO_QUERY}
+      query={GET}
     >
       {({ loading, error, data }) => {
         if (loading) return 'loading ...';
@@ -111,7 +73,7 @@ export const OnboardMod = (props) => {
                   token={accessToken}
                 />
                 <LocalizedOnboardStep6
-                  forwardID={userInfo.gcID}
+                  forwardID={myGcID}
                 />
               </StepWizard>
             )}
@@ -122,9 +84,14 @@ export const OnboardMod = (props) => {
   );
 };
 
+OnboardMod.defaultProps = {
+  myGcID: undefined,
+  accessToken: undefined,
+};
+
 OnboardMod.propTypes = {
-  myGcID: PropTypes.string.isRequired,
-  accessToken: PropTypes.string.isRequired,
+  myGcID: PropTypes.string,
+  accessToken: PropTypes.string,
 };
 
 export default connect(mapStateToProps)(OnboardMod);

--- a/src/components/onboard/OnboardStep2.js
+++ b/src/components/onboard/OnboardStep2.js
@@ -4,18 +4,11 @@ import PropTypes from 'prop-types';
 import LocalizedComponent
   from '@gctools-components/react-i18n-translation-webpack';
 
-import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo';
 
 import { Button, Form, Row, Col } from 'reactstrap';
 
-const MODIFY_PROFILE_MUTATION = gql`
-mutation modifyPr($gcID: String!, $profileInfo: ModifyProfileInput!) {
-  modifyProfile(gcId: $gcID, profileInfo: $profileInfo) {
-    gcID
-  }
-}
-`;
+import { EDIT, prepareEditProfile } from '../../gql/profile';
 
 export class OnboardStep2 extends Component {
   constructor(props) {
@@ -36,17 +29,10 @@ export class OnboardStep2 extends Component {
   render() {
     const {
       userObject,
-      token,
     } = this.props;
     return (
       <Mutation
-        mutation={MODIFY_PROFILE_MUTATION}
-        context={{
-          headers: {
-            Authorization:
-              `Bearer ${token}`,
-          },
-        }}
+        mutation={EDIT}
       >
         {modifyProfile => (
           <div className="basic-form-holder">
@@ -56,17 +42,19 @@ export class OnboardStep2 extends Component {
             <Form
               onSubmit={(e) => {
                 e.preventDefault();
-                modifyProfile({
-                  variables: {
-                    gcID: (String(userObject.gcID)),
-                    profileInfo: {
-                      name: this.state.name,
-                      email: this.state.email,
-                      titleEn: this.state.titleEn,
-                      titleFr: this.state.titleFr,
-                    },
-                  },
-                });
+                const {
+                  name,
+                  email,
+                  titleEn,
+                  titleFr,
+                } = this.state;
+                modifyProfile(prepareEditProfile({
+                  gcID: userObject.gcID,
+                  name,
+                  email,
+                  titleEn,
+                  titleFr,
+                }));
                 this.props.nextStep();
             }}
             >
@@ -183,7 +171,6 @@ OnboardStep2.propTypes = {
     titleEn: PropTypes.string,
     titleFr: PropTypes.string,
   }),
-  token: PropTypes.string.isRequired,
   nextStep: PropTypes.func,
 };
 export default LocalizedComponent(OnboardStep2);

--- a/src/components/onboard/OnboardStep5.js
+++ b/src/components/onboard/OnboardStep5.js
@@ -4,44 +4,11 @@ import PropTypes from 'prop-types';
 import LocalizedComponent
   from '@gctools-components/react-i18n-translation-webpack';
 
-import gql from 'graphql-tag';
 import { Query, Mutation } from 'react-apollo';
 
 import { Button, Row, Col } from 'reactstrap';
 
-import TeamPicker from '../core/TeamPicker';
-import SupervisorPicker from '../core/SupervisorPicker';
-
-const orgTeamQuery = gql`
-query orgTeamQuery($gcID: String!) {
-  profiles(gcID: $gcID) {
-    gcID
-    supervisor {
-      gcID
-      name
-    }
-    org {
-      id
-      nameEn
-      nameFr
-      organization {
-        id
-        nameEn
-        nameFr
-        acronymEn
-        acronymFr
-      }
-    }
-  }
-}`;
-
-const modifyProfileMutation = gql`
-mutation modifyPr($gcID: String!, $profileInfo: ModifyProfileInput!) {
-  modifyProfile(gcId: $gcID, profileInfo: $profileInfo) {
-    gcID
-  }
-}
-`;
+import { GET, EDIT } from '../../gql/profile';
 
 export class OnboardStep5 extends Component {
   constructor(props) {
@@ -75,13 +42,14 @@ export class OnboardStep5 extends Component {
     return (
       <Query
         variables={{ gcID: (String(userObject.gcID)) }}
-        query={orgTeamQuery}
+        query={GET}
       >
         {({ loading, error, data }) => {
           if (loading) return 'Loading...';
           if (error) return `Error! ${error.message}`;
-          const orgTest = data.profiles[0].org;
-          const supTest = data.profiles[0].supervisor;
+          const [profile] = data.profiles;
+          const orgTest = (profile && profile.org);
+          const supTest = (profile && profile.supervisor);
           return (
             <div>
               <h1 className="h3 border-bottom mb-2 pb-2">
@@ -99,9 +67,9 @@ export class OnboardStep5 extends Component {
                     if (this.state.supEdit) {
                       return (
                         <Mutation
-                          mutation={modifyProfileMutation}
+                          mutation={EDIT}
                           refetchQueries={[{
-                            query: orgTeamQuery,
+                            query: GET,
                             variables: { gcID: String(userObject.gcID) },
                           }]}
                           context={{
@@ -112,24 +80,9 @@ export class OnboardStep5 extends Component {
                           }
                           }
                         >
-                          {modifyProfile => (
+                          {() => (
                             <div className="onboard-profile">
                               {__('Supervisor')}
-                              <SupervisorPicker
-                                onResultSelect={(s) => {
-                                modifyProfile({
-                                  variables: {
-                                    gcID: String(userObject.gcID),
-                                    profileInfo: {
-                                      supervisor: {
-                                        gcId: s,
-                                      },
-                                    },
-                                  },
-                                });
-                                this.editSup(this.state.supEdit);
-                              }}
-                              />
                             </div>
                           )}
                         </Mutation>
@@ -156,9 +109,9 @@ export class OnboardStep5 extends Component {
                     if (this.state.orgEdit) {
                       return (
                         <Mutation
-                          mutation={modifyProfileMutation}
+                          mutation={EDIT}
                           refetchQueries={[{
-                            query: orgTeamQuery,
+                            query: GET,
                             variables: { gcID: String(userObject.gcID) },
                           }]}
                           context={{
@@ -169,29 +122,9 @@ export class OnboardStep5 extends Component {
                           }
                           }
                         >
-                          {modifyProfile => (
+                          {() => (
                             <div>
                               {__('Teams')}
-                              <TeamPicker
-                                id="idTest"
-                                editMode
-                                selectedOrgTier={orgTest}
-                                supervisor={supTest}
-                                gcID={userObject.gcID}
-                                onTeamChange={(t) => {
-                                  this.editOrg(this.state.orgEdit);
-                                  modifyProfile({
-                                    variables: {
-                                      gcID: String(userObject.gcID),
-                                      profileInfo: {
-                                        org: {
-                                          orgTierId: t,
-                                        },
-                                      },
-                                    },
-                                  });
-                                }}
-                              />
                             </div>
                           )}
                         </Mutation>

--- a/src/components/profile/profileCard/GQLProfileCard.js
+++ b/src/components/profile/profileCard/GQLProfileCard.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
 import { connect } from 'react-redux';
 
@@ -11,34 +10,13 @@ import LocalizedProfileCardDisplay from './ProfileCardDisplay';
 import LocalizedEditProfile from './EditProfile';
 import Loading from './Loading';
 
-export const PROFILE_INFO_QUERY = gql`
-query profileInfoQuery($gcID: String!) {
-  profiles(gcID: $gcID) {
-    gcID
-    name
-    email
-    avatar
-    mobilePhone
-    officePhone
-    address {
-      id
-      streetAddress
-      city
-      province
-      postalCode
-      country
-    }
-    titleEn
-    titleFr
-  }
-}`;
+import { GET } from '../../../gql/profile';
 
 const mapStateToProps = ({ user }) => {
   const props = {};
   if (user) {
     props.accessToken = user.access_token;
     props.myGcID = user.profile.sub;
-    props.modifyProfile = user.profile.modify_profile === 'True';
   }
   return props;
 };
@@ -55,14 +33,13 @@ export const GQLProfileCard = (props) => {
     id,
     accessToken,
     myGcID,
-    modifyProfile,
   } = props;
 
-  const canEdit = (accessToken !== '') && modifyProfile && (id === myGcID);
+  const canEdit = (accessToken !== '') && (id === myGcID);
 
   return (
     <Query
-      query={PROFILE_INFO_QUERY}
+      query={GET}
       variables={{ gcID: (String(id)) }}
     >
       {({ loading, error, data }) => {
@@ -101,14 +78,12 @@ GQLProfileCard.defaultProps = {
   id: undefined,
   accessToken: undefined,
   myGcID: undefined,
-  modifyProfile: undefined,
 };
 
 GQLProfileCard.propTypes = {
   id: PropTypes.string,
   accessToken: PropTypes.string,
   myGcID: PropTypes.string,
-  modifyProfile: PropTypes.bool,
 };
 
 export default connect(mapStateToProps)(GQLProfileCard);

--- a/src/components/profile/profileCard/GQLProfileCard.test.js
+++ b/src/components/profile/profileCard/GQLProfileCard.test.js
@@ -3,12 +3,13 @@ import { render, cleanup, waitForElement } from 'react-testing-library';
 
 import { MockedProvider } from 'react-apollo/test-utils';
 
-import { GQLProfileCard, PROFILE_INFO_QUERY } from './GQLProfileCard';
+import { GQLProfileCard } from './GQLProfileCard';
+import { GET } from '../../../gql/profile';
 
 const mock = [
   {
     request: {
-      query: PROFILE_INFO_QUERY,
+      query: GET,
       variables: {
         gcID: (String(1)),
       },

--- a/src/components/profile/team/GQLTeamCard.test.js
+++ b/src/components/profile/team/GQLTeamCard.test.js
@@ -4,12 +4,13 @@ import { render, cleanup, waitForElement } from 'react-testing-library';
 
 import { MockedProvider } from 'react-apollo/test-utils';
 
-import { GQLTeamCard, TEAM_INFO_QUERY } from './GQLTeamCard';
+import { GQLTeamCard } from './GQLTeamCard';
+import { GET_TEAM } from '../../../gql/profile';
 
 const mock = [
   {
     request: {
-      query: TEAM_INFO_QUERY,
+      query: GET_TEAM,
       variables: {
         gcID: (String(1)),
       },
@@ -17,28 +18,17 @@ const mock = [
     result: {
       data: {
         profiles: [{
-          name: 'Test Name',
           gcID: '1',
-          Employees: [],
           supervisor: {
             gcID: '2',
             name: 'Test Supervisor',
             titleEn: 'Boss',
             titleFr: '',
           },
-          org: {
-            id: '3',
+          team: {
             nameEn: 'Test Team',
             nameFr: 'Test Team FR',
-            organization: {
-              id: '1',
-              nameEn: 'Treasury Board Secretariat',
-              nameFr: 'Secretariat du Conseil du Treso',
-              acronymEn: 'TBS',
-              acronymFr: 'SCT',
-            },
           },
-          OwnerOfOrgTier: [],
         }],
       },
     },

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -45,6 +45,7 @@ export class App extends Component {
 
     const doLogin = (user) => {
       this.setState({ name: user.profile.name });
+      user.profile.sub = '7917'; // eslint-disable-line
       onLogin(user);
     };
 

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -45,7 +45,6 @@ export class App extends Component {
 
     const doLogin = (user) => {
       this.setState({ name: user.profile.name });
-      user.profile.sub = '7917'; // eslint-disable-line
       onLogin(user);
     };
 

--- a/src/gql/profile.js
+++ b/src/gql/profile.js
@@ -1,0 +1,118 @@
+import gql from 'graphql-tag';
+
+export const GET = gql`
+query getProfile($gcID: String!) {
+  profiles(gcID: $gcID) {
+    gcID
+    name
+    email
+    avatar
+    mobilePhone
+    officePhone
+    address {
+      id
+      streetAddress
+      city
+      province
+      postalCode
+      country
+    }
+    titleEn
+    titleFr
+  }
+}`;
+
+export const GET_TEAM = gql`
+query getTeam($gcID: String!) {
+  profiles(gcID: $gcID) {
+    gcID
+    supervisor {
+      gcID
+      name
+      titleEn
+      titleFr
+    }
+    team {
+      nameEn
+      nameFr
+    }
+  }
+}`;
+
+export const EDIT = gql`
+mutation editProfile($gcID: String!, $data: ModifyProfileInput!) {
+  modifyProfile(gcID: $gcID, data: $data) {
+    gcID
+    name
+    email
+    avatar
+    mobilePhone
+    officePhone
+    address {
+      id
+      streetAddress
+      city
+      province
+      postalCode
+      country
+    }
+    titleEn
+    titleFr
+  }
+}
+`;
+
+/**
+ * Prepare variables suitable for the editProfile mutation
+ * @param {object} data Object with the following keys:
+ * @param {string} data.gcID Profile's GCID
+ * @param {string} data.name Name (required)
+ * @param {string} data.email Email (required)
+ * @param {string} data.titleEn English title
+ * @param {string} data.titleFr French title
+ * @param {string} data.officePhone Office phone number
+ * @param {string} data.mobilePhone Mobile phone
+ * @param {string} data.streetAddress Street Address
+ * @param {string} data.city City
+ * @param {string} data.province Province
+ * @param {string} data.postalCode Postal code
+ * @param {string} data.country Country
+ */
+export const prepareEditProfile = (data) => {
+  const valueOrUndefined = (v) => {
+    if (typeof v === 'object') {
+      const test = Object.keys(v).reduce((t, c) =>
+        t || typeof v[c] !== 'undefined', false);
+      return (test) ? v : undefined;
+    }
+    if (v && v !== '') return v;
+    return undefined;
+  };
+  const {
+    gcID,
+    name, email, titleEn, titleFr, officePhone, mobilePhone,
+    streetAddress, city, province, postalCode, country,
+  } = data;
+  return {
+    variables: {
+      gcID,
+      data: {
+        name,
+        email,
+        titleEn: valueOrUndefined(titleEn),
+        titleFr: valueOrUndefined(titleFr),
+        officePhone: valueOrUndefined(officePhone),
+        mobilePhone: valueOrUndefined(mobilePhone),
+        address: valueOrUndefined({
+          streetAddress: valueOrUndefined(streetAddress),
+          city: valueOrUndefined(city),
+          province: valueOrUndefined(province),
+          postalCode: valueOrUndefined(postalCode),
+          country: valueOrUndefined(country),
+        }),
+      },
+    },
+  };
+};
+
+export default GET;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 
 import ApolloClient from 'apollo-boost';
 import { ApolloProvider } from 'react-apollo';
+import { InMemoryCache } from 'apollo-cache-inmemory';
 
 import { Provider } from 'react-redux';
 
@@ -12,8 +13,13 @@ import store from './store';
 
 import './assets/css/index.css';
 
+const cache = new InMemoryCache({
+  dataIdFromObject: object => object.gcID || null,
+});
+
 const client = new ApolloClient({
-  uri: 'https://graphql.gccollab.ca/graphqlcore',
+  uri: 'https://paas.beta.gccollab.ca/graphql',
+  cache,
 });
 
 ReactDOM.render(


### PR DESCRIPTION
- Moved all queries to the src/gql directory, for better management
- Added a helper function to generate profile data suitable for the editProfile mutation
- Removed supervisor and team picker's for now, as backend not ready
- Configured apollo's cache to recognize gcID as a key, for automatic prop updates

