### PR TITLE
Aurora package + error fix test + remove supervisor mutation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/core": "7.3.3",
+    "@gctools-components/aurora-css": "^0.3.3",
     "@gctools-components/eslint-config": "1.1.3",
     "@gctools-components/gc-login": "1.1.3",
     "@gctools-components/i18n-translation-webpack-plugin": "2.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,6 @@
       homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link rel="stylesheet" type="text/css" href="https://aurora.gccollab.ca/cdn/aurora.min.css">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/components/core/DepartmentPicker.js
+++ b/src/components/core/DepartmentPicker.js
@@ -83,7 +83,7 @@ class DepartmentPicker extends React.Component {
                 <Input
                   type="text"
                   onChange={this.handleChange}
-                  value={this.state.value}
+                  value={(this.state.value) ? this.state.value : ''}
                 />
               </label>
               <ul className={styleClasses}>

--- a/src/gql/profile.js
+++ b/src/gql/profile.js
@@ -131,9 +131,6 @@ mutation editProfile($gcID: ID!, $data: ModifyProfileInput!) {
     }
     titleEn
     titleFr
-    supervisor {
-      gcID
-    }
   }
 }
 `;

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ import { ApolloProvider } from 'react-apollo';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { createUploadLink } from 'apollo-upload-client';
 
+import '@gctools-components/aurora-css/css/aurora.min.css';
+
 import { Provider } from 'react-redux';
 
 import ConnectedAndLocalizedApp from './containers/App';

--- a/yarn.lock
+++ b/yarn.lock
@@ -994,6 +994,10 @@
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.1.3.tgz#b700d97385fa91affed60c71dfd51c67e9dad762"
 
+"@gctools-components/aurora-css@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@gctools-components/aurora-css/-/aurora-css-0.3.3.tgz#23b7d0bdfddd4123122b30b1f10f7d9999bdfc00"
+
 "@gctools-components/eslint-config@1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gctools-components/eslint-config/-/eslint-config-1.1.3.tgz#cde4d904bf3a7791c0b2cee58979bfe35c2d5a07"


### PR DESCRIPTION
Various changes
- removed cdn link to css and replaced with aurora css package (site styles are now updated with latest styles)
- attempt to fix https://github.com/gctools-outilsgc/directory-fe/issues/17
- removed instance of supervisor return that still existed in a mutation