### PR TITLE
Transfer modal fix

### DIFF
--- a/i18n/en_CA/LC_MESSAGES/src/components/profile/team/GQLTeamCard.js.po
+++ b/i18n/en_CA/LC_MESSAGES/src/components/profile/team/GQLTeamCard.js.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-25 15:14-0500\n"
+"POT-Creation-Date: 2019-03-31 15:47-0400\n"
 "PO-Revision-Date: 2019-02-21 14:05-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en_CA\n"
@@ -24,5 +24,9 @@ msgstr ""
 
 #: 92:22 src/components/profile/team/GQLTeamCard.js
 msgid "Cannot find GCID"
+msgstr ""
+
+#: 313:45 src/components/profile/team/GQLTeamCard.js
+msgid "None"
 msgstr ""
 

--- a/i18n/fr_CA/LC_MESSAGES/src/components/profile/team/GQLTeamCard.js.po
+++ b/i18n/fr_CA/LC_MESSAGES/src/components/profile/team/GQLTeamCard.js.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-02-25 15:14-0500\n"
+"POT-Creation-Date: 2019-03-31 15:47-0400\n"
 "PO-Revision-Date: 2019-02-21 14:05-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr_CA\n"
@@ -24,5 +24,9 @@ msgstr "Équipes"
 
 #: 92:22 src/components/profile/team/GQLTeamCard.js
 msgid "Cannot find GCID"
+msgstr ""
+
+#: 313:45 src/components/profile/team/GQLTeamCard.js
+msgid "None"
 msgstr ""
 

--- a/i18n/templates/src/components/profile/team/GQLTeamCard.js.pot
+++ b/i18n/templates/src/components/profile/team/GQLTeamCard.js.pot
@@ -18,3 +18,7 @@ msgstr ""
 msgid "Cannot find GCID"
 msgstr ""
 
+#: src/components/profile/team/GQLTeamCard.js 313:45
+msgid "None"
+msgstr ""
+

--- a/src/components/core/TeamPicker.js
+++ b/src/components/core/TeamPicker.js
@@ -5,6 +5,8 @@ import { Input } from 'reactstrap';
 
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
+import LocalizedComponent
+  from '@gctools-components/react-i18n-translation-webpack';
 
 
 class TeamPicker extends React.Component {
@@ -16,10 +18,8 @@ class TeamPicker extends React.Component {
     this.handleTeamChange = this.handleTeamChange.bind(this);
   }
 
-  handleTeamChange(e) {
-    const teamObj = [];
-    teamObj.id = e.target.value;
-    teamObj.name = e.target.innerText;
+  handleTeamChange(e, teams) {
+    const teamObj = teams.find(team => team.id === e.target.value);
     this.props.onTeamChange(teamObj);
     this.setState({
       newTeamVal: teamObj.id,
@@ -71,7 +71,6 @@ class TeamPicker extends React.Component {
               ownerOfTeams = []
                 .concat([data.profiles[0].org], ownerOfTeams);
           }
-
           const tierOptions = [];
           tierOptions.push({
             key: 'orgtier-undefined',
@@ -83,7 +82,8 @@ class TeamPicker extends React.Component {
             .forEach(tier =>
               tierOptions.push({
                 key: `orgtier-${tier.id}`,
-                text: tier.nameEn, // Localize later
+                nameEn: tier.nameEn,
+                nameFr: tier.nameFr,
                 value: tier.id,
                 data: tier,
               }));
@@ -92,12 +92,14 @@ class TeamPicker extends React.Component {
             <div>
               <Input
                 type="select"
-                onChange={this.handleTeamChange}
+                onChange={evt => this.handleTeamChange(evt, ownerOfTeams)}
                 disabled={!supervisor || loading}
                 value={(this.state.newTeamVal) ? this.state.newTeamVal.id : ''}
               >
                 {tierOptions.map(x => (
-                  <option key={x.value} value={x.value}>{x.text}</option>
+                  <option key={x.value} value={x.value}>
+                    {(localizer.lang === 'en_CA') ? x.nameEn : x.nameFr}
+                  </option>
               ))}
               </Input>
             </div>
@@ -132,4 +134,4 @@ TeamPicker.propTypes = {
   supervisor: PropTypes.shape({}).isRequired,
 };
 
-export default TeamPicker;
+export default LocalizedComponent(TeamPicker);

--- a/src/components/profile/team/GQLTeamCard.js
+++ b/src/components/profile/team/GQLTeamCard.js
@@ -307,14 +307,23 @@ export class GQLTeamCard extends React.Component {
                               {modifyProfile => this.state.confirmModal && (
                                 <TransferConfirmation
                                   isOpen={this.state.confirmModal}
-                                  source={supTest}
+                                  source={
+                                    (supTest !== null) ? supTest :
+                                    {
+                                       name: __('None'),
+                                       team: {
+                                         nameEn: teamTest.nameEn,
+                                         nameFr: teamTest.nameFr,
+                                       },
+                                    }}
                                   transferredUser={userInfo}
                                   destination={
                                     {
                                       name: chosenSupervisor.name,
                                       avatar: chosenSupervisor.avatar,
                                       team: {
-                                        name: chosenTeam.name,
+                                        nameEn: chosenTeam.nameEn,
+                                        nameFr: chosenTeam.nameFr,
                                         avatar: chosenTeam.avatar,
                                       },
                                     }

--- a/src/components/profile/team/TransferConfirmation.js
+++ b/src/components/profile/team/TransferConfirmation.js
@@ -5,6 +5,9 @@ import PropTypes from 'prop-types';
 
 import styled from 'styled-components';
 
+import LocalizedComponent
+  from '@gctools-components/react-i18n-translation-webpack';
+
 import {
   Modal,
   ModalHeader,
@@ -115,30 +118,25 @@ const Avatars = styled.div`
 const getProfileDetails = (profile) => {
   const {
     name,
-    avatar: profileAvatar,
+    avatar,
     team,
     titleEn,
     titleFr,
   } = profile || {};
-  const avatar = profileAvatar || GenericAvatar;
-  if (!name && !team) {
+  if (!name) {
     return {
-      name: ((profile.nameEn === '') && __('Default Team')) ||
-        ((localizer.lang === 'en_CA') ? profile.nameEn : profile.nameFr),
+      name: (localizer.lang === 'en_CA') ? profile.nameEn : profile.nameFr,
       isTeam: true,
     };
   }
   return {
     isTeam: false,
     name,
-    avatar,
+    avatar: avatar || GenericAvatar,
     title: (localizer.lang === 'en_CA') ? titleEn : titleFr,
     team: {
       id: team && team.id,
-      name:
-        team && (
-          ((team.nameEn === '') && __('Default Team')) ||
-          ((localizer.lang === 'en_CA') ? team.nameEn : team.nameFr)),
+      name: team && ((localizer.lang === 'en_CA') ? team.nameEn : team.nameFr),
       avatar: team && team.avatar,
     }
   };
@@ -194,7 +192,10 @@ const TransferConfirmation = (props) => {
           <Avatars delete={props.delete}>
             {user1.isTeam && (
               <React.Fragment>
-                <TeamAvatar className="tcd-team-avatar" name={user1.name} />
+                <TeamAvatar
+                  className="tcd-team-avatar"
+                  name={user1.name}
+                />
                 <div className="name">
                   <h2>{user1.name}</h2>
                 </div>
@@ -207,11 +208,11 @@ const TransferConfirmation = (props) => {
                   alt={`${avatarAltText} ${user1.name}`}
                 />
                 <div className="team">
-                  <TeamAvatar name={user1.team.name} />
+                  <TeamAvatar name={user2.team.name} />
                 </div>
                 <div className="name">
                   <h2>{user1.name}</h2>
-                  <span>{user1.team.name}</span>
+                  <span>{user2.team.name}</span>
                 </div>
               </React.Fragment>
             )}
@@ -366,4 +367,4 @@ TransferConfirmation.propTypes = {
   delete: PropTypes.bool,
 };
 
-export default TransferConfirmation;
+export default LocalizedComponent(TransferConfirmation);

--- a/src/components/profile/team/TransferConfirmation.js
+++ b/src/components/profile/team/TransferConfirmation.js
@@ -16,6 +16,7 @@ import {
 import TeamAvatar from './TeamAvatar';
 
 import varTag from '../../../utils/cssVarTag';
+import GenericAvatar from '../../profile/OrgChart/Card/img/user.gif';
 
 
 const Arrow = styled.div`
@@ -114,11 +115,12 @@ const Avatars = styled.div`
 const getProfileDetails = (profile) => {
   const {
     name,
-    avatar,
+    avatar: profileAvatar,
     team,
     titleEn,
     titleFr,
   } = profile || {};
+  const avatar = profileAvatar || GenericAvatar;
   if (!name && !team) {
     return {
       name: ((profile.nameEn === '') && __('Default Team')) ||


### PR DESCRIPTION
This fixes the confirm transfer modal for the following issues:
1. When a user was in the global team and did not have a supervisor the transfer confirmation would crash
 - Solution : Logic check in GQLTeamCard to see if supervisor is null and if yes pass in a custom object that has None as supervisor and the global team info
2. Localization logic issue on Transfer Modal from Team Picker.  Only the english name and ID sent back to parent
- Solution: The whole team object is passed into Team Picker so it only made sense to pass a whole object back out again.  This allows for localization on team name in the parent component that can be passed as props in other children.
3. If avatar was null is was displaying a broken link
- Solution: Added generic avatar to Transfer Confirmation.
4. Transfer Confirmation design did not match original concept.  Both Supervisor and Destination profiles were displaying the teams they belonged to and not what team the user was from and going to.
- Solution: Rearranged data on render() to conform to design.