### PR TITLE
Can no longer click a team in the org chart

### DIFF
--- a/src/components/profile/OrgChart/algorithm/nrc_orgchart_placement.js
+++ b/src/components/profile/OrgChart/algorithm/nrc_orgchart_placement.js
@@ -868,8 +868,8 @@ export const profileToNode = (profile, team) => (
       root: false,
     } :
     {
-      uuid: team.id,
-      gcID: team.id,
+      uuid: 'team',
+      gcID: 'team',
       name: (localizer.lang === 'en_CA') ? team.nameEn : team.nameFr,
       department: {
         en_CA: team.nameEn,

--- a/src/components/profile/team/GQLTeamOrgChart.js
+++ b/src/components/profile/team/GQLTeamOrgChart.js
@@ -60,8 +60,10 @@ export class GQLTeamOrgChart extends React.Component {
   }
   navigateToProfile(card) {
     const { history } = this.props;
-    history.push(`/p/${card.id}`);
-    this.setState({ selected: card.id });
+    if (card.id !== 'team') {
+      history.push(`/p/${card.id}`);
+      this.setState({ selected: card.id });
+    }
   }
   moveToLoggedInUser() {
     this.setState({ selected: this.props.myGcID });


### PR DESCRIPTION
If a user is a member of the default organisation team, you can no longer click on that team node in the org chart.

Zube issue 5072