### PR TITLE
Update to new version of global-nav package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@gctools-components/aurora-css": "0.3.3",
     "@gctools-components/eslint-config": "1.1.3",
     "@gctools-components/gc-login": "1.1.3",
-    "@gctools-components/global-nav": "^0.4.9",
+    "@gctools-components/global-nav": "^0.4.11",
     "@gctools-components/i18n-translation-webpack-plugin": "2.0.2",
     "@gctools-components/react-i18n-translation-webpack": "1.1.4",
     "@storybook/addon-actions": "5.0.3",


### PR DESCRIPTION
Updated the global-nav to the new 0.4.11 version.

To work fully will need to update naas.beta to newest version as well.