### PR TITLE
make user avatar images links to their profiles

### DIFF
--- a/src/components/core/UserAvatar.js
+++ b/src/components/core/UserAvatar.js
@@ -23,6 +23,7 @@ export const UserAvatar = (props) => {
     avatar: profileAvatar,
     gcID,
     size,
+    url,
   } = props;
   const canEdit = edit && (gcID === myGcID);
   const avatar = profileAvatar || GenericAvatar;
@@ -31,7 +32,7 @@ export const UserAvatar = (props) => {
     <div>
       <div className="query">
         <div className="d-flex justify-content-center">
-          <a href={gcID}>
+          <a href={url}>
             <img
               className={`avatar rounded-circle avatar-${size}`}
               src={avatar}
@@ -83,6 +84,7 @@ UserAvatar.defaultProps = {
   myGcID: '',
   avatar: '',
   size: '',
+  url: null,
 };
 
 UserAvatar.propTypes = {
@@ -92,6 +94,7 @@ UserAvatar.propTypes = {
   avatar: PropTypes.string,
   myGcID: PropTypes.string,
   size: PropTypes.string,
+  url: PropTypes.string,
 };
 
 export default LocalizedComponent(UserAvatar);

--- a/src/components/core/UserAvatar.js
+++ b/src/components/core/UserAvatar.js
@@ -31,11 +31,13 @@ export const UserAvatar = (props) => {
     <div>
       <div className="query">
         <div className="d-flex justify-content-center">
-          <img
-            className={`avatar rounded-circle avatar-${size}`}
-            src={avatar}
-            alt={name}
-          />
+          <a href={gcID}>
+            <img
+              className={`avatar rounded-circle avatar-${size}`}
+              src={avatar}
+              alt={name}
+            />
+          </a>
         </div>
         {canEdit && (
         <UploadContainer className="mutate">

--- a/src/components/core/UserAvatar.js
+++ b/src/components/core/UserAvatar.js
@@ -23,7 +23,6 @@ export const UserAvatar = (props) => {
     avatar: profileAvatar,
     gcID,
     size,
-    url,
   } = props;
   const canEdit = edit && (gcID === myGcID);
   const avatar = profileAvatar || GenericAvatar;
@@ -32,13 +31,11 @@ export const UserAvatar = (props) => {
     <div>
       <div className="query">
         <div className="d-flex justify-content-center">
-          <a href={url}>
-            <img
-              className={`avatar rounded-circle avatar-${size}`}
-              src={avatar}
-              alt={name}
-            />
-          </a>
+          <img
+            className={`avatar rounded-circle avatar-${size}`}
+            src={avatar}
+            alt={name}
+          />
         </div>
         {canEdit && (
         <UploadContainer className="mutate">
@@ -84,7 +81,6 @@ UserAvatar.defaultProps = {
   myGcID: '',
   avatar: '',
   size: '',
-  url: null,
 };
 
 UserAvatar.propTypes = {
@@ -94,7 +90,6 @@ UserAvatar.propTypes = {
   avatar: PropTypes.string,
   myGcID: PropTypes.string,
   size: PropTypes.string,
-  url: PropTypes.string,
 };
 
 export default LocalizedComponent(UserAvatar);

--- a/src/components/profile/team/GQLTeamCard.js
+++ b/src/components/profile/team/GQLTeamCard.js
@@ -120,7 +120,7 @@ function GQLTeamCard(props) {
                         <div className="d-flex">
                           <UserAvatar
                             avatar={supTest ? supTest.avatar : ''}
-                            name={supTest ? supTest.name : ''}
+                            name=""
                           />
                           <div className="ml-2">
                             <div className="text-dark font-weight-bold">

--- a/src/components/profile/team/GQLTeamCard.js
+++ b/src/components/profile/team/GQLTeamCard.js
@@ -120,7 +120,7 @@ function GQLTeamCard(props) {
                         <UserAvatar
                           avatar={supTest ? supTest.avatar : ''}
                           name={supTest ? supTest.name : ''}
-                          gcID={supTest ? supTest.gcID : ''}
+                          url={supTest ? supTest.gcID : ''}
                         />
                         <div className="ml-2">
                           <div>

--- a/src/components/profile/team/GQLTeamCard.js
+++ b/src/components/profile/team/GQLTeamCard.js
@@ -120,6 +120,7 @@ function GQLTeamCard(props) {
                         <UserAvatar
                           avatar={supTest ? supTest.avatar : ''}
                           name={supTest ? supTest.name : ''}
+                          gcID={supTest ? supTest.gcID : ''}
                         />
                         <div className="ml-2">
                           <div>

--- a/src/components/profile/team/GQLTeamCard.js
+++ b/src/components/profile/team/GQLTeamCard.js
@@ -116,27 +116,22 @@ function GQLTeamCard(props) {
                       <div className="font-weight-bold mb-2">
                         {__('Supervisor')}
                       </div>
-                      <div className="d-flex">
-                        <UserAvatar
-                          avatar={supTest ? supTest.avatar : ''}
-                          name={supTest ? supTest.name : ''}
-                          url={supTest ? supTest.gcID : ''}
-                        />
-                        <div className="ml-2">
-                          <div>
-                            <a
-                              href={supTest ?
-                                supTest.gcID : ''}
-                              className="text-dark font-weight-bold"
-                            >
+                      <a href={supTest ? supTest.gcID : ''} >
+                        <div className="d-flex">
+                          <UserAvatar
+                            avatar={supTest ? supTest.avatar : ''}
+                            name={supTest ? supTest.name : ''}
+                          />
+                          <div className="ml-2">
+                            <div className="text-dark font-weight-bold">
                               {supTest ? supTest.name : 'N/A'}
-                            </a>
+                            </div>
+                            <small className="text-muted">
+                              {supTest ? supTest.titleEn : 'N/A'}
+                            </small>
                           </div>
-                          <small className="text-muted">
-                            {supTest ? supTest.titleEn : 'N/A'}
-                          </small>
                         </div>
-                      </div>
+                      </a>
                       {canEdit ?
                         <div className="ml-5">
                           <Button

--- a/src/components/profile/team/TeamDisplayMemberList.js
+++ b/src/components/profile/team/TeamDisplayMemberList.js
@@ -14,7 +14,7 @@ const TeamDisplayMemberList = (props) => {
           <UserAvatar
             avatar={p ? p.avatar : ''}
             name={p ? p.name : ''}
-            gcID={p ? p.gcID : ''}
+            url={p ? p.gcID : ''}
           />
           <div className="ml-2 font-weight-bold">
             <div>

--- a/src/components/profile/team/TeamDisplayMemberList.js
+++ b/src/components/profile/team/TeamDisplayMemberList.js
@@ -10,33 +10,28 @@ const TeamDisplayMemberList = (props) => {
   const list = (members) ?
     members.map(p => (
       <Col sm="4" className="mb-3" key={p.gcID}>
-        <div className="d-flex">
-          <UserAvatar
-            avatar={p ? p.avatar : ''}
-            name={p ? p.name : ''}
-            url={p ? p.gcID : ''}
-          />
-          <div className="ml-2 font-weight-bold">
-            <div>
-              <a
-                href={p ?
-                  p.gcID : ''}
-                className="text-dark"
-              >
+        <a href={p ? p.gcID : ''} >
+          <div className="d-flex">
+            <UserAvatar
+              avatar={p ? p.avatar : ''}
+              name={p ? p.name : ''}
+            />
+            <div className="ml-2 font-weight-bold">
+              <div className="text-dark">
                 {p ? p.name : 'None'}
-              </a>
+              </div>
+              {(localizer.lang === 'en_CA') ? (
+                <small className="text-muted">
+                  {p ? p.titleEn : ''}
+                </small>
+              ) : (
+                <small className="text-muted">
+                  {p ? p.titleFr : ''}
+                </small>
+              )}
             </div>
-            {(localizer.lang === 'en_CA') ? (
-              <small className="text-muted">
-                {p ? p.titleEn : ''}
-              </small>
-            ) : (
-              <small className="text-muted">
-                {p ? p.titleFr : ''}
-              </small>
-            )}
           </div>
-        </div>
+        </a>
       </Col>
     )) : 'No Team';
   return (

--- a/src/components/profile/team/TeamDisplayMemberList.js
+++ b/src/components/profile/team/TeamDisplayMemberList.js
@@ -14,7 +14,7 @@ const TeamDisplayMemberList = (props) => {
           <div className="d-flex">
             <UserAvatar
               avatar={p ? p.avatar : ''}
-              name={p ? p.name : ''}
+              name=""
             />
             <div className="ml-2 font-weight-bold">
               <div className="text-dark">

--- a/src/components/profile/team/TeamDisplayMemberList.js
+++ b/src/components/profile/team/TeamDisplayMemberList.js
@@ -14,6 +14,7 @@ const TeamDisplayMemberList = (props) => {
           <UserAvatar
             avatar={p ? p.avatar : ''}
             name={p ? p.name : ''}
+            gcID={p ? p.gcID : ''}
           />
           <div className="ml-2 font-weight-bold">
             <div>


### PR DESCRIPTION
Extends the user profile link to include the avatar image and title in the team tab lists.

closes  gctools-outilsgc/profile_service_react#44