### PR TITLE
Change to team query and render

### DIFF
--- a/i18n/en_CA/LC_MESSAGES/src/components/profile/team/GQLTeamCard.js.po
+++ b/i18n/en_CA/LC_MESSAGES/src/components/profile/team/GQLTeamCard.js.po
@@ -71,3 +71,5 @@ msgstr ""
 msgid "You cannot be your own supervisor. Please pick someone else."
 msgstr ""
 
+msgid "No Team"
+msgstr ""

--- a/i18n/fr_CA/LC_MESSAGES/src/components/profile/team/GQLTeamCard.js.po
+++ b/i18n/fr_CA/LC_MESSAGES/src/components/profile/team/GQLTeamCard.js.po
@@ -74,3 +74,5 @@ msgstr "Confirmer"
 msgid "You cannot be your own supervisor. Please pick someone else."
 msgstr ""
 
+msgid "No Team"
+msgstr "Aucune équipe"

--- a/src/components/profile/team/GQLTeamCard.js
+++ b/src/components/profile/team/GQLTeamCard.js
@@ -361,7 +361,7 @@ function GQLTeamCard(props) {
                     {__('people')}
                   </div>
                   {teamTest.nameEn == 'Global Team' ? (
-                    <div>No Team</div>
+                    <div>{__('No Team')}</div>
                   ) : (
                     <TeamDisplayMemberList
                       userID={(String(id))}

--- a/src/components/profile/team/GQLTeamCard.js
+++ b/src/components/profile/team/GQLTeamCard.js
@@ -22,7 +22,7 @@ import ErrorModal, { err } from '../../core/ErrorModal';
 
 import Loading from './Loading';
 
-import { GET_TEAM, EDIT_TEAM } from '../../../gql/profile';
+import { GET_TEAM_NAME, EDIT_TEAM } from '../../../gql/profile';
 import SupervisorPicker from '../../core/SupervisorPicker';
 // import TeamPicker from '../../core/TeamPicker';
 import { UserAvatar } from '../../core/UserAvatar';
@@ -83,7 +83,7 @@ function GQLTeamCard(props) {
   const canEdit = (accessToken !== '') && (id === myGcID);
   return (
     <Query
-      query={GET_TEAM}
+      query={GET_TEAM_NAME}
       variables={{ gcID: (String(id)) }}
     >
       {({
@@ -96,7 +96,7 @@ function GQLTeamCard(props) {
         const userInfo = (!data) ? '' : data.profiles[0];
         const teamTest = (!userInfo) ? '' : userInfo.team;
         const supTest = (!teamTest) ? '' : userInfo.team.owner;
-        const memberTest = (!teamTest) ? '' : userInfo.team.members;
+        // const memberTest = (!teamTest) ? '' : userInfo.team.members;
         return (
           <div style={style.card}>
             {userInfo ? (
@@ -280,7 +280,7 @@ function GQLTeamCard(props) {
                           <Mutation
                             mutation={EDIT_TEAM}
                             refetchQueries={[{
-                              query: GET_TEAM,
+                              query: GET_TEAM_NAME,
                               variables: { gcID: String(userInfo.gcID) },
                             }]}
                             onError={(e) => {
@@ -360,9 +360,13 @@ function GQLTeamCard(props) {
                   <div className="font-weight-bold">
                     {__('people')}
                   </div>
-                  <TeamDisplayMemberList
-                    members={memberTest}
-                  />
+                  {teamTest.nameEn == 'Global Team' ? (
+                    <div>No Team</div>
+                  ) : (
+                    <TeamDisplayMemberList
+                      userID={(String(id))}
+                    />
+                  )}
                 </div>
               </div>
             ) : (

--- a/src/components/profile/team/TeamDisplayMemberList.js
+++ b/src/components/profile/team/TeamDisplayMemberList.js
@@ -1,47 +1,46 @@
+/* eslint-disable */
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Col, Row } from 'reactstrap';
+import { Query } from 'react-apollo';
 
+import { GET_TEAM_MEMBERS } from '../../../gql/profile';
 import { UserAvatar } from '../../core/UserAvatar';
+import Loading from './Loading';
 
-const TeamDisplayMemberList = (props) => {
-  const { members } = props;
-  const list = (members) ?
-    members.map(p => (
-      <Col sm="4" className="mb-3" key={p.gcID}>
-        <a href={p ? p.gcID : ''} >
-          <div className="d-flex">
-            <UserAvatar
-              avatar={p ? p.avatar : ''}
-              name=""
-            />
-            <div className="ml-2 font-weight-bold">
-              <div className="text-dark">
-                {p ? p.name : 'None'}
-              </div>
-              {(localizer.lang === 'en_CA') ? (
-                <small className="text-muted">
-                  {p ? p.titleEn : ''}
-                </small>
-              ) : (
-                <small className="text-muted">
-                  {p ? p.titleFr : ''}
-                </small>
-              )}
-            </div>
-          </div>
-        </a>
-      </Col>
-    )) : 'No Team';
+const MemberList = (props) => {
+  const { p } = props;
   return (
-    <Row className="mt-3">
-      {list}
-    </Row>
+    <Col sm="4" className="mb-3" key={p.gcID}>
+      <a href={p ? p.gcID : ''} >
+        <div className="d-flex">
+          <UserAvatar
+            avatar={p ? p.avatar : ''}
+            name=""
+          />
+          <div className="ml-2 font-weight-bold">
+            <div className="text-dark">
+              {p ? p.name : 'None'}
+            </div>
+            {(localizer.lang === 'en_CA') ? (
+              <small className="text-muted">
+                {p ? p.titleEn : ''}
+              </small>
+            ) : (
+              <small className="text-muted">
+                {p ? p.titleFr : ''}
+              </small>
+            )}
+          </div>
+        </div>
+      </a>
+    </Col>
   );
 };
-
+/*
 TeamDisplayMemberList.propTypes = {
+  userID: PropTypes.isRequired,
   members: PropTypes.arrayOf(PropTypes.shape({
     gcID: PropTypes.string,
     avatar: PropTypes.string,
@@ -50,5 +49,34 @@ TeamDisplayMemberList.propTypes = {
     titleFr: PropTypes.string,
   })).isRequired,
 };
+*/
+const TeamDisplayMemberList = (props) => {
+  const { userID } = props;
+  return (
+    <Query
+      query={GET_TEAM_MEMBERS}
+      variables={{ gcID: (String(userID)) }}
+    >
+      {({
+        loading,
+        error,
+        data,
+      }) => {
+        if (loading) return <Loading />;
+        if (error) return errorHandler(error);
+        const members = (!data) ? '' : data.profiles[0].team.members;
+        const list = (members) ?
+          members.map(p => (
+            <MemberList p={p} />
+          )): 'No Team';
+        return(
+          <Row className="mt-3">
+            {list}
+          </Row>
+        );
+      }}
+    </Query>
+  );
+}
 
 export default TeamDisplayMemberList;

--- a/src/components/profile/team/TeamDisplayMemberList.js
+++ b/src/components/profile/team/TeamDisplayMemberList.js
@@ -68,7 +68,7 @@ const TeamDisplayMemberList = (props) => {
         const list = (members) ?
           members.map(p => (
             <MemberList p={p} />
-          )): 'No Team';
+          )): 'N/A';
         return(
           <Row className="mt-3">
             {list}

--- a/src/gql/profile.js
+++ b/src/gql/profile.js
@@ -173,6 +173,50 @@ query getTeam($gcID: ID!) {
 ${FullTeamFragment}
 `;
 
+export const GET_TEAM_NAME = gql`
+query getTeamName($gcID: ID!) {
+  profiles(gcID: $gcID) {
+    gcID
+    name
+    team {
+      id
+      nameEn
+      nameFr
+      organization {
+        id,
+        nameEn,
+        nameFr
+      }
+      owner {
+        gcID
+        name
+        avatar
+        titleEn
+        titleFr
+      }
+    }
+  }
+}
+`;
+
+export const GET_TEAM_MEMBERS = gql`
+query getTeamMembers($gcID: ID!) {
+  profiles(gcID: $gcID) {
+    gcID
+    team {
+      id
+      members {
+        gcID
+        name
+        titleEn
+        titleFr
+        avatar
+      }
+    }
+  }
+}
+`;
+
 export const GET_YOUR_TEAM = gql`
 query getYourTeam($gcID: ID!) {
   profiles(gcID: $gcID) {


### PR DESCRIPTION
Modified the team member display to not display global team members as well as broke up team query into 2 (get team name and info first then team members) to prevent long loads of global or large teams.