### PR TITLE
Get global team translate in french when toggle

### DIFF
--- a/src/components/profile/team/GQLTeamCard.js
+++ b/src/components/profile/team/GQLTeamCard.js
@@ -354,7 +354,7 @@ function GQLTeamCard(props) {
                       <div className="font-weight-bold mb-2">
                         {__('Team')}
                       </div>
-                      {teamTest ? teamTest.nameEn : 'N/A'}
+                      {(localizer.lang == 'en_CA') ? (teamTest) ? teamTest.nameEn : 'N/A' : (teamTest) ? teamTest.nameFr : 'N/A'}
                     </Col>
                   </Row>
                   <hr />


### PR DESCRIPTION
Related to https://zube.io/tbs-sct/gctools/c/5947

Add the if condition that check the language and provide the team name in the right language.