### PR TITLE
No result in dropdown search

### DIFF
--- a/i18n/en_CA/LC_MESSAGES/src/components/core/ProfileSearch.js.po
+++ b/i18n/en_CA/LC_MESSAGES/src/components/core/ProfileSearch.js.po
@@ -22,3 +22,6 @@ msgstr ""
 msgid "Search Profiles"
 msgstr "Search Directory"
 
+#: 67:112 src/components/core/ProfileSearch.js
+msgid "No result found"
+msgstr ""

--- a/i18n/fr_CA/LC_MESSAGES/src/components/core/ProfileSearch.js.po
+++ b/i18n/fr_CA/LC_MESSAGES/src/components/core/ProfileSearch.js.po
@@ -22,3 +22,6 @@ msgstr "Rechercher"
 msgid "Search Profiles"
 msgstr "Recherche sur Annuaire"
 
+#: 67:112 src/components/core/ProfileSearch.js
+msgid "No result found"
+msgstr "Aucun résultat trouvé"

--- a/src/components/core/ProfileSearch.js
+++ b/src/components/core/ProfileSearch.js
@@ -108,7 +108,7 @@ class ProfileSearch extends React.Component {
                   </InputGroupAddon>
                 </InputGroup>
               </label>
-              <ul className={styleClasses}>{results}</ul>
+               <ul className={styleClasses}>{results.length > 0 ? results : __('No result found')}</ul> {/* eslint-disable-line */}
             </div>
           );
         }}


### PR DESCRIPTION
When using the search bar, if no result is returning, instead of showing an empty section, it will show a 'no result found' message with the translation.

fix issue #142 