### PR TITLE
Remove ability to select previous slides in onboarding

### DIFF
--- a/src/components/onboard/OnboardStep1.js
+++ b/src/components/onboard/OnboardStep1.js
@@ -10,7 +10,7 @@ import { Button, Row } from 'reactstrap';
 export class OnboardStep1 extends Component {
   render() {
     return (
-      <div>
+      <div className={this.props.isActive ? '' : 'd-none'}>
         <h1 className="h3 mb-2 pb-1">
           {__('Welcome')}
         </h1>

--- a/src/components/onboard/OnboardStep2.js
+++ b/src/components/onboard/OnboardStep2.js
@@ -48,10 +48,9 @@ export class OnboardStep2 extends Component {
         mutation={EDIT}
       >
         {modifyProfile => (
-          <div className="basic-form-holder">
-            <h1 className="sr-only">
-                          Hidden Heading?
-            </h1>
+          <div
+            className={this.props.isActive ? 'basic-form-holder' : 'd-none'}
+          >
             <Form
               onSubmit={(e) => {
                 e.preventDefault();
@@ -75,9 +74,9 @@ export class OnboardStep2 extends Component {
             >
               <Row className="pb-2 mb-3 mt-3">
                 <Col sm="12">
-                  <h2 className="h4 mb-2 pb-2 border-bottom text-primary">
+                  <h1 className="h4 mb-2 pb-2 border-bottom text-primary">
                     {__('Step2T1')}
-                  </h2>
+                  </h1>
                   <p>{__('Step2D1')}</p>
                 </Col>
                 <Col md="6">
@@ -207,6 +206,7 @@ export class OnboardStep2 extends Component {
 OnboardStep2.defaultProps = {
   userObject: {},
   nextStep: undefined,
+  isActive: undefined,
 };
 
 OnboardStep2.propTypes = {
@@ -225,5 +225,6 @@ OnboardStep2.propTypes = {
     }),
   }),
   nextStep: PropTypes.func,
+  isActive: PropTypes.bool,
 };
 export default LocalizedComponent(OnboardStep2);

--- a/src/components/onboard/OnboardStep3.js
+++ b/src/components/onboard/OnboardStep3.js
@@ -61,7 +61,7 @@ export class OnboardStep3 extends Component {
               }));
               this.props.nextStep();
             }}
-            className="basic-form-holder"
+            className={this.props.isActive ? 'basic-form-holder' : 'd-none'}
           >
             <h1 className="mb-2 pb-2 h3 text-primary">
               {__('Step3T1')}
@@ -249,6 +249,7 @@ OnboardStep3.defaultProps = {
   userObject: { address: {} },
   nextStep: undefined,
   previousStep: undefined,
+  isActive: undefined,
 };
 
 OnboardStep3.propTypes = {
@@ -267,6 +268,7 @@ OnboardStep3.propTypes = {
   }),
   nextStep: PropTypes.func,
   previousStep: PropTypes.func,
+  isActive: PropTypes.bool,
 };
 
 export default LocalizedComponent(OnboardStep3);

--- a/src/components/onboard/OnboardStep4.js
+++ b/src/components/onboard/OnboardStep4.js
@@ -14,7 +14,7 @@ export class OnboardStep4 extends Component {
       userObject,
     } = this.props;
     return (
-      <div>
+      <div className={this.props.isActive ? '' : 'd-none'}>
         <h1 className="h3 border-bottom mb-2 pb-2">
           {__('Step4T1')}
         </h1>

--- a/src/components/onboard/OnboardStep5.js
+++ b/src/components/onboard/OnboardStep5.js
@@ -48,7 +48,7 @@ export class OnboardStep5 extends Component {
     const supTest = (!teamTest) ? '' : userObject.team.owner;
 
     return (
-      <div>
+      <div className={this.props.isActive ? '' : 'd-none'}>
         <h1 className="h3 border-bottom mb-2 pb-2">
           {__('Step5T1')}
         </h1>
@@ -189,6 +189,7 @@ OnboardStep5.defaultProps = {
   userObject: {},
   nextStep: undefined,
   previousStep: undefined,
+  isActive: undefined,
 };
 
 OnboardStep5.propTypes = {
@@ -197,6 +198,7 @@ OnboardStep5.propTypes = {
   }),
   nextStep: PropTypes.func,
   previousStep: PropTypes.func,
+  isActive: PropTypes.bool,
 };
 
 export default LocalizedComponent(OnboardStep5);


### PR DESCRIPTION
Users can no longer select the fields from previous slides in onboarding.

Also fixed a header issue on Step 2.

Closes #168 